### PR TITLE
Fix textarea border radius when resized

### DIFF
--- a/components/prompt-form.tsx
+++ b/components/prompt-form.tsx
@@ -118,7 +118,7 @@ export function PromptForm({
           }
         }}
       />
-      <div className="relative flex max-h-60 w-full grow flex-col overflow-hidden bg-zinc-100 px-12 sm:rounded-full sm:px-12">
+      <div className="relative flex max-h-60 w-full grow flex-col overflow-hidden bg-zinc-100 px-12 sm:rounded-[31px] sm:px-12">
         {/* <Tooltip>
           <TooltipTrigger asChild> */}
         <Button


### PR DESCRIPTION
Before:

<img width="742" alt="image" src="https://github.com/vercel-labs/gemini-chatbot/assets/31038284/a777d25c-de72-4c97-a828-f6232eb6bb23">


After:

<img width="703" alt="image" src="https://github.com/vercel-labs/gemini-chatbot/assets/31038284/2aaccdfb-c789-4652-a7f9-1170db1d24b5">
