### PR TITLE
Update `history.tsx` to use correct filter when deleting item from list

### DIFF
--- a/components/custom/history.tsx
+++ b/components/custom/history.tsx
@@ -74,7 +74,7 @@ export const History = ({ user }: { user: User | undefined }) => {
       success: () => {
         mutate((history) => {
           if (history) {
-            return history.filter((h) => h.id !== id);
+            return history.filter((h) => h.id !== deleteId);
           }
         });
         return "Chat deleted successfully";


### PR DESCRIPTION
The current code is filtering based on id (from useParams() at the top), which is the ID of the chat currently being viewed in the URL, not the one being deleted.

The code now correctly filters out the chat with the deleteId rather than the current URL id.

This ensures that:
1. The correct chat is removed from the history list after deletion
2. The filter operation matches the chat being deleted rather than the currently viewed chat
3. The UI will update properly to reflect the deleted item