### PR TITLE
fix: use correct comment syntax in .env.example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,8 @@ GOOGLE_GENERATIVE_AI_API_KEY=****
 # Generate a random secret: https://generate-secret.vercel.app/32 or `openssl rand -base64 32`
 AUTH_SECRET=****
 
-/*
- * The following keys below are automatically created and
- * added to your environment when you deploy on vercel
- */
+# The following keys below are automatically created and
+# added to your environment when you deploy on vercel
 
 # Instructions to create kv database here: https://vercel.com/docs/storage/vercel-blob
 BLOB_READ_WRITE_TOKEN=****


### PR DESCRIPTION
## Description
Fixed incorrect comment syntax in `.env.example` file. The file was using JavaScript-style block comments (`/* */`) which is not valid for environment files. Changed to use proper hash-based comments (`#`).

## Changes
- Replaced `/* */` block comment with `#` line comments in `.env.example`

## Why
Environment files (`.env`) only support `#` for comments. Using `/* */` could cause confusion for developers or potential parsing issues with certain tools.
