### PR TITLE
Apply blue theme across all CSS design tokens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,16 +3,16 @@
 @tailwind utilities;
 
 :root {
-    --foreground-rgb: 0, 0, 0;
-    --background-start-rgb: 214, 219, 220;
-    --background-end-rgb: 255, 255, 255;
+    --foreground-rgb: 15, 40, 80;
+    --background-start-rgb: 214, 228, 245;
+    --background-end-rgb: 235, 245, 255;
 }
 
 @media (prefers-color-scheme: dark) {
     :root {
-        --foreground-rgb: 255, 255, 255;
-        --background-start-rgb: 0, 0, 0;
-        --background-end-rgb: 0, 0, 0;
+        --foreground-rgb: 210, 230, 255;
+        --background-start-rgb: 5, 15, 35;
+        --background-end-rgb: 10, 25, 55;
     }
 }
 
@@ -24,57 +24,57 @@
 
 @layer base {
     :root {
-        --background: 0 0% 100%;
-        --foreground: 240 10% 3.9%;
-        --card: 0 0% 100%;
-        --card-foreground: 240 10% 3.9%;
-        --popover: 0 0% 100%;
-        --popover-foreground: 240 10% 3.9%;
-        --primary: 244 40% 63%;
-        --primary-foreground: 0 0% 98%;
-        --secondary: 240 4.8% 95.9%;
-        --secondary-foreground: 240 5.9% 10%;
-        --muted: 240 4.8% 95.9%;
-        --muted-foreground: 240 3.8% 46.1%;
-        --accent: 240 4.8% 95.9%;
-        --accent-foreground: 240 5.9% 10%;
+        --background: 210 60% 98%;
+        --foreground: 215 60% 12%;
+        --card: 210 50% 96%;
+        --card-foreground: 215 60% 12%;
+        --popover: 210 50% 96%;
+        --popover-foreground: 215 60% 12%;
+        --primary: 215 85% 45%;
+        --primary-foreground: 210 100% 98%;
+        --secondary: 210 40% 88%;
+        --secondary-foreground: 215 60% 15%;
+        --muted: 210 40% 92%;
+        --muted-foreground: 215 30% 40%;
+        --accent: 200 70% 80%;
+        --accent-foreground: 215 60% 12%;
         --destructive: 0 84.2% 60.2%;
         --destructive-foreground: 0 0% 98%;
-        --border: 240 5.9% 90%;
-        --input: 240 5.9% 90%;
-        --ring: 246, 47%, 65%;
-        --chart-1: 12 76% 61%;
-        --chart-2: 173 58% 39%;
-        --chart-3: 197 37% 24%;
-        --chart-4: 43 74% 66%;
-        --chart-5: 27 87% 67%;
+        --border: 210 40% 82%;
+        --input: 210 40% 82%;
+        --ring: 215 85% 55%;
+        --chart-1: 215 85% 45%;
+        --chart-2: 200 70% 50%;
+        --chart-3: 225 60% 40%;
+        --chart-4: 190 65% 55%;
+        --chart-5: 240 55% 60%;
         --radius: 0.75rem;
     }
     .dark {
-        --background: 240 10% 3.9%;
-        --foreground: 0 0% 98%;
-        --card: 240 10% 3.9%;
-        --card-foreground: 0 0% 98%;
-        --popover: 240 10% 3.9%;
-        --popover-foreground: 0 0% 98%;
-        --primary: 244 40% 63%;
-        --primary-foreground: 240 5.9% 10%;
-        --secondary: 240 3.7% 15.9%;
-        --secondary-foreground: 0 0% 98%;
-        --muted: 240 3.7% 15.9%;
-        --muted-foreground: 240 5% 64.9%;
-        --accent: 240 3.7% 15.9%;
-        --accent-foreground: 0 0% 98%;
+        --background: 220 50% 6%;
+        --foreground: 210 80% 92%;
+        --card: 220 45% 9%;
+        --card-foreground: 210 80% 92%;
+        --popover: 220 45% 9%;
+        --popover-foreground: 210 80% 92%;
+        --primary: 215 85% 55%;
+        --primary-foreground: 220 50% 6%;
+        --secondary: 220 40% 16%;
+        --secondary-foreground: 210 80% 92%;
+        --muted: 220 40% 14%;
+        --muted-foreground: 210 40% 60%;
+        --accent: 210 50% 22%;
+        --accent-foreground: 210 80% 92%;
         --destructive: 0 62.8% 30.6%;
         --destructive-foreground: 0 0% 98%;
-        --border: 240 3.7% 15.9%;
-        --input: 240 3.7% 15.9%;
-        --ring: 240 4.9% 83.9%;
-        --chart-1: 220 70% 50%;
-        --chart-2: 160 60% 45%;
-        --chart-3: 30 80% 55%;
-        --chart-4: 280 65% 60%;
-        --chart-5: 340 75% 55%;
+        --border: 220 40% 18%;
+        --input: 220 40% 18%;
+        --ring: 215 85% 55%;
+        --chart-1: 215 85% 55%;
+        --chart-2: 200 70% 55%;
+        --chart-3: 225 60% 50%;
+        --chart-4: 190 65% 60%;
+        --chart-5: 240 55% 65%;
     }
 }
 


### PR DESCRIPTION
## Summary

- Shifts all CSS custom property color values in `globals.css` to blue hues for both light and dark modes
- Updates backgrounds, foregrounds, cards, popovers, primary/secondary/muted/accent colors, borders, inputs, rings, and all chart colors to a cohesive blue palette
- Light mode uses soft blue-tinted whites with a vivid blue primary; dark mode uses deep navy backgrounds with bright blue accents