### PR TITLE
Make everything blue

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -41,18 +41,18 @@ export default function Page() {
     <div className="flex h-screen w-screen items-center justify-center bg-background">
       <div className="w-full max-w-md overflow-hidden rounded-2xl flex flex-col gap-12">
         <div className="flex flex-col items-center justify-center gap-2 px-4 text-center sm:px-16">
-          <h3 className="text-xl font-semibold dark:text-zinc-50">Sign In</h3>
-          <p className="text-sm text-gray-500 dark:text-zinc-400">
+           <h3 className="text-xl font-semibold dark:text-blue-50">Sign In</h3>
+          <p className="text-sm text-blue-500 dark:text-blue-400">
             Use your email and password to sign in
           </p>
         </div>
         <AuthForm action={handleSubmit} defaultEmail={email}>
           <SubmitButton>Sign in</SubmitButton>
-          <p className="text-center text-sm text-gray-600 mt-4 dark:text-zinc-400">
+          <p className="text-center text-sm text-blue-600 mt-4 dark:text-blue-400">
             {"Don't have an account? "}
             <Link
               href="/register"
-              className="font-semibold text-gray-800 hover:underline dark:text-zinc-200"
+              className="font-semibold text-blue-800 hover:underline dark:text-blue-200"
             >
               Sign up
             </Link>

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -43,18 +43,18 @@ export default function Page() {
     <div className="flex h-screen w-screen items-center justify-center bg-background">
       <div className="w-full max-w-md overflow-hidden rounded-2xl gap-12 flex flex-col">
         <div className="flex flex-col items-center justify-center gap-2 px-4 text-center sm:px-16">
-          <h3 className="text-xl font-semibold dark:text-zinc-50">Sign Up</h3>
-          <p className="text-sm text-gray-500 dark:text-zinc-400">
+          <h3 className="text-xl font-semibold dark:text-blue-50">Sign Up</h3>
+          <p className="text-sm text-blue-500 dark:text-blue-400">
             Create an account with your email and password
           </p>
         </div>
         <AuthForm action={handleSubmit} defaultEmail={email}>
           <SubmitButton>Sign Up</SubmitButton>
-          <p className="text-center text-sm text-gray-600 mt-4 dark:text-zinc-400">
+          <p className="text-center text-sm text-blue-600 mt-4 dark:text-blue-400">
             {"Already have an account? "}
             <Link
               href="/login"
-              className="font-semibold text-gray-800 hover:underline dark:text-zinc-200"
+              className="font-semibold text-blue-800 hover:underline dark:text-blue-200"
             >
               Sign in
             </Link>

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,16 +3,16 @@
 @tailwind utilities;
 
 :root {
-    --foreground-rgb: 0, 0, 0;
-    --background-start-rgb: 214, 219, 220;
-    --background-end-rgb: 255, 255, 255;
+    --foreground-rgb: 15, 30, 80;
+    --background-start-rgb: 219, 234, 254;
+    --background-end-rgb: 239, 246, 255;
 }
 
 @media (prefers-color-scheme: dark) {
     :root {
-        --foreground-rgb: 255, 255, 255;
-        --background-start-rgb: 0, 0, 0;
-        --background-end-rgb: 0, 0, 0;
+        --foreground-rgb: 219, 234, 254;
+        --background-start-rgb: 15, 23, 42;
+        --background-end-rgb: 23, 37, 84;
     }
 }
 
@@ -24,57 +24,57 @@
 
 @layer base {
     :root {
-        --background: 0 0% 100%;
-        --foreground: 240 10% 3.9%;
-        --card: 0 0% 100%;
-        --card-foreground: 240 10% 3.9%;
-        --popover: 0 0% 100%;
-        --popover-foreground: 240 10% 3.9%;
-        --primary: 244 40% 63%;
-        --primary-foreground: 0 0% 98%;
-        --secondary: 240 4.8% 95.9%;
-        --secondary-foreground: 240 5.9% 10%;
-        --muted: 240 4.8% 95.9%;
-        --muted-foreground: 240 3.8% 46.1%;
-        --accent: 240 4.8% 95.9%;
-        --accent-foreground: 240 5.9% 10%;
+        --background: 214 100% 97%;
+        --foreground: 221 70% 15%;
+        --card: 213 100% 96%;
+        --card-foreground: 221 70% 15%;
+        --popover: 213 100% 96%;
+        --popover-foreground: 221 70% 15%;
+        --primary: 217 91% 50%;
+        --primary-foreground: 0 0% 100%;
+        --secondary: 214 95% 90%;
+        --secondary-foreground: 221 70% 20%;
+        --muted: 214 95% 92%;
+        --muted-foreground: 215 40% 40%;
+        --accent: 214 95% 88%;
+        --accent-foreground: 221 70% 20%;
         --destructive: 0 84.2% 60.2%;
         --destructive-foreground: 0 0% 98%;
-        --border: 240 5.9% 90%;
-        --input: 240 5.9% 90%;
-        --ring: 246, 47%, 65%;
-        --chart-1: 12 76% 61%;
-        --chart-2: 173 58% 39%;
-        --chart-3: 197 37% 24%;
-        --chart-4: 43 74% 66%;
-        --chart-5: 27 87% 67%;
+        --border: 214 80% 83%;
+        --input: 214 80% 83%;
+        --ring: 217 91% 50%;
+        --chart-1: 217 91% 50%;
+        --chart-2: 199 89% 48%;
+        --chart-3: 230 85% 60%;
+        --chart-4: 207 90% 54%;
+        --chart-5: 188 80% 44%;
         --radius: 0.75rem;
     }
     .dark {
-        --background: 240 10% 3.9%;
-        --foreground: 0 0% 98%;
-        --card: 240 10% 3.9%;
-        --card-foreground: 0 0% 98%;
-        --popover: 240 10% 3.9%;
-        --popover-foreground: 0 0% 98%;
-        --primary: 244 40% 63%;
-        --primary-foreground: 240 5.9% 10%;
-        --secondary: 240 3.7% 15.9%;
-        --secondary-foreground: 0 0% 98%;
-        --muted: 240 3.7% 15.9%;
-        --muted-foreground: 240 5% 64.9%;
-        --accent: 240 3.7% 15.9%;
-        --accent-foreground: 0 0% 98%;
-        --destructive: 0 62.8% 30.6%;
+        --background: 224 71% 8%;
+        --foreground: 213 100% 94%;
+        --card: 224 65% 11%;
+        --card-foreground: 213 100% 94%;
+        --popover: 224 65% 11%;
+        --popover-foreground: 213 100% 94%;
+        --primary: 217 91% 60%;
+        --primary-foreground: 224 71% 8%;
+        --secondary: 224 55% 18%;
+        --secondary-foreground: 213 100% 94%;
+        --muted: 224 55% 18%;
+        --muted-foreground: 215 50% 65%;
+        --accent: 224 55% 22%;
+        --accent-foreground: 213 100% 94%;
+        --destructive: 0 62.8% 45%;
         --destructive-foreground: 0 0% 98%;
-        --border: 240 3.7% 15.9%;
-        --input: 240 3.7% 15.9%;
-        --ring: 240 4.9% 83.9%;
-        --chart-1: 220 70% 50%;
-        --chart-2: 160 60% 45%;
-        --chart-3: 30 80% 55%;
-        --chart-4: 280 65% 60%;
-        --chart-5: 340 75% 55%;
+        --border: 224 45% 22%;
+        --input: 224 45% 22%;
+        --ring: 217 91% 60%;
+        --chart-1: 217 91% 60%;
+        --chart-2: 199 89% 55%;
+        --chart-3: 230 85% 65%;
+        --chart-4: 207 90% 60%;
+        --chart-5: 188 80% 50%;
     }
 }
 

--- a/components/custom/auth-form.tsx
+++ b/components/custom/auth-form.tsx
@@ -15,7 +15,7 @@ export function AuthForm({
       <div className="flex flex-col gap-2">
         <Label
           htmlFor="email"
-          className="text-zinc-600 font-normal dark:text-zinc-400"
+          className="text-blue-600 font-normal dark:text-blue-400"
         >
           Email Address
         </Label>
@@ -33,7 +33,7 @@ export function AuthForm({
 
         <Label
           htmlFor="password"
-          className="text-zinc-600 font-normal dark:text-zinc-400"
+          className="text-blue-600 font-normal dark:text-blue-400"
         >
           Password
         </Label>

--- a/components/custom/history.tsx
+++ b/components/custom/history.tsx
@@ -115,9 +115,9 @@ export const History = ({ user }: { user: User | undefined }) => {
 
           <div className="text-sm flex flex-row items-center justify-between">
             <div className="flex flex-row gap-2">
-              <div className="dark:text-zinc-300">History</div>
+              <div className="dark:text-blue-200">History</div>
 
-              <div className="dark:text-zinc-400 text-zinc-500">
+              <div className="dark:text-blue-400 text-blue-500">
                 {history === undefined ? "loading" : history.length} chats
               </div>
             </div>
@@ -138,14 +138,14 @@ export const History = ({ user }: { user: User | undefined }) => {
 
             <div className="flex flex-col overflow-y-scroll p-1 h-[calc(100dvh-124px)]">
               {!user ? (
-                <div className="text-zinc-500 h-dvh w-full flex flex-row justify-center items-center text-sm gap-2">
+                <div className="text-blue-500 h-dvh w-full flex flex-row justify-center items-center text-sm gap-2">
                   <InfoIcon />
                   <div>Login to save and revisit previous chats!</div>
                 </div>
               ) : null}
 
               {!isLoading && history?.length === 0 && user ? (
-                <div className="text-zinc-500 h-dvh w-full flex flex-row justify-center items-center text-sm gap-2">
+                <div className="text-blue-500 h-dvh w-full flex flex-row justify-center items-center text-sm gap-2">
                   <InfoIcon />
                   <div>No chats found</div>
                 </div>
@@ -156,7 +156,7 @@ export const History = ({ user }: { user: User | undefined }) => {
                   {[44, 32, 28, 52].map((item) => (
                     <div key={item} className="p-2 my-[2px]">
                       <div
-                        className={`w-${item} h-[20px] rounded-md bg-zinc-200 dark:bg-zinc-600 animate-pulse`}
+                        className={`w-${item} h-[20px] rounded-md bg-blue-200 dark:bg-blue-700 animate-pulse`}
                       />
                     </div>
                   ))}
@@ -168,14 +168,14 @@ export const History = ({ user }: { user: User | undefined }) => {
                   <div
                     key={chat.id}
                     className={cx(
-                      "flex flex-row items-center gap-6 hover:bg-zinc-200 dark:hover:bg-zinc-700 rounded-md pr-2",
-                      { "bg-zinc-200 dark:bg-zinc-700": chat.id === id },
+                      "flex flex-row items-center gap-6 hover:bg-blue-200 dark:hover:bg-blue-800 rounded-md pr-2",
+                      { "bg-blue-200 dark:bg-blue-800": chat.id === id },
                     )}
                   >
                     <Button
                       variant="ghost"
                       className={cx(
-                        "hover:bg-zinc-200 dark:hover:bg-zinc-700 justify-between p-0 text-sm font-normal flex flex-row items-center gap-2 pr-2 w-full transition-none",
+                        "hover:bg-blue-200 dark:hover:bg-blue-800 justify-between p-0 text-sm font-normal flex flex-row items-center gap-2 pr-2 w-full transition-none",
                       )}
                       asChild
                     >
@@ -190,7 +190,7 @@ export const History = ({ user }: { user: User | undefined }) => {
                     <DropdownMenu modal={true}>
                       <DropdownMenuTrigger asChild>
                         <Button
-                          className="p-0 h-fit font-normal text-zinc-500 transition-none hover:bg-zinc-200 dark:hover:bg-zinc-700"
+                          className="p-0 h-fit font-normal text-blue-500 transition-none hover:bg-blue-200 dark:hover:bg-blue-800"
                           variant="ghost"
                         >
                           <MoreHorizontalIcon />

--- a/components/custom/message.tsx
+++ b/components/custom/message.tsx
@@ -35,13 +35,13 @@ export const Message = ({
       initial={{ y: 5, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
     >
-      <div className="size-[24px] border rounded-sm p-1 flex flex-col justify-center items-center shrink-0 text-zinc-500">
+      <div className="size-[24px] border rounded-sm p-1 flex flex-col justify-center items-center shrink-0 text-blue-500">
         {role === "assistant" ? <BotIcon /> : <UserIcon />}
       </div>
 
       <div className="flex flex-col gap-2 w-full">
         {content && typeof content === "string" && (
-          <div className="text-zinc-800 dark:text-zinc-300 flex flex-col gap-4">
+          <div className="text-blue-900 dark:text-blue-200 flex flex-col gap-4">
             <Streamdown>{content}</Streamdown>
           </div>
         )}

--- a/components/custom/multimodal-input.tsx
+++ b/components/custom/multimodal-input.tsx
@@ -173,10 +173,10 @@ export function MultimodalInput({
                       content: suggestedAction.action,
                     });
                   }}
-                  className="border-none bg-muted/50 w-full text-left border border-zinc-200 dark:border-zinc-800 text-zinc-800 dark:text-zinc-300 rounded-lg p-3 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors flex flex-col"
+                  className="border-none bg-muted/50 w-full text-left border border-blue-200 dark:border-blue-800 text-blue-800 dark:text-blue-300 rounded-lg p-3 text-sm hover:bg-blue-100 dark:hover:bg-blue-900 transition-colors flex flex-col"
                 >
                   <span className="font-medium">{suggestedAction.title}</span>
-                  <span className="text-zinc-500 dark:text-zinc-400">
+                  <span className="text-blue-500 dark:text-blue-400">
                     {suggestedAction.label}
                   </span>
                 </button>
@@ -258,7 +258,7 @@ export function MultimodalInput({
       )}
 
       <Button
-        className="rounded-full p-1.5 h-fit absolute bottom-2 right-10 m-0.5 dark:border-zinc-700"
+        className="rounded-full p-1.5 h-fit absolute bottom-2 right-10 m-0.5 dark:border-blue-700"
         onClick={(event) => {
           event.preventDefault();
           fileInputRef.current?.click();

--- a/components/custom/navbar.tsx
+++ b/components/custom/navbar.tsx
@@ -29,10 +29,10 @@ export const Navbar = async () => {
               width={20}
               alt="gemini logo"
             />
-            <div className="text-zinc-500">
+            <div className="text-blue-400">
               <SlashIcon size={16} />
             </div>
-            <div className="text-sm dark:text-zinc-300 truncate w-28 md:w-fit">
+            <div className="text-sm dark:text-blue-200 truncate w-28 md:w-fit">
               Next.js Gemini Chatbot
             </div>
           </div>

--- a/components/custom/overview.tsx
+++ b/components/custom/overview.tsx
@@ -13,8 +13,8 @@ export const Overview = () => {
       exit={{ opacity: 0, scale: 0.98 }}
       transition={{ delay: 0.5 }}
     >
-      <div className="border-none bg-muted/50 rounded-2xl p-6 flex flex-col gap-4 text-zinc-500 text-sm dark:text-zinc-400 dark:border-zinc-700">
-        <p className="flex flex-row justify-center gap-4 items-center text-zinc-900 dark:text-zinc-50">
+      <div className="border-none bg-muted/50 rounded-2xl p-6 flex flex-col gap-4 text-blue-600 text-sm dark:text-blue-400 dark:border-blue-700">
+        <p className="flex flex-row justify-center gap-4 items-center text-blue-900 dark:text-blue-50">
           <VercelIcon />
           <span>+</span>
           <MessageIcon />

--- a/components/custom/preview-attachment.tsx
+++ b/components/custom/preview-attachment.tsx
@@ -32,13 +32,13 @@ export const PreviewAttachment = ({
         )}
 
         {isUploading && (
-          <div className="animate-spin absolute text-zinc-500">
+          <div className="animate-spin absolute text-blue-500">
             <LoaderIcon />
           </div>
         )}
       </div>
 
-      <div className="text-xs text-zinc-500 max-w-16 truncate">{name}</div>
+      <div className="text-xs text-blue-500 max-w-16 truncate">{name}</div>
     </div>
   );
 };

--- a/components/custom/weather.tsx
+++ b/components/custom/weather.tsx
@@ -256,7 +256,7 @@ export function Weather({
           "bg-blue-400": isDay,
         },
         {
-          "bg-indigo-900": !isDay,
+          "bg-blue-900": !isDay,
         },
       )}
     >
@@ -266,10 +266,10 @@ export function Weather({
             className={cx(
               "size-10 rounded-full skeleton-div",
               {
-                "bg-yellow-300": isDay,
+                "bg-blue-200": isDay,
               },
               {
-                "bg-indigo-100": !isDay,
+                "bg-blue-300": !isDay,
               },
             )}
           />
@@ -292,10 +292,10 @@ export function Weather({
               className={cx(
                 "size-6 rounded-full skeleton-div",
                 {
-                  "bg-yellow-300": isDay,
+                  "bg-blue-200": isDay,
                 },
                 {
-                  "bg-indigo-200": !isDay,
+                  "bg-blue-300": !isDay,
                 },
               )}
             />

--- a/components/flights/authorize-payment.tsx
+++ b/components/flights/authorize-payment.tsx
@@ -52,11 +52,11 @@ export function AuthorizePayment({
   };
 
   return reservation?.hasCompletedPayment ? (
-    <div className="bg-emerald-500 p-4 rounded-lg gap-4 flex flex-row justify-between items-center">
-      <div className="dark:text-emerald-950 text-emerald-50 font-medium">
+    <div className="bg-blue-500 p-4 rounded-lg gap-4 flex flex-row justify-between items-center">
+      <div className="dark:text-blue-950 text-blue-50 font-medium">
         Payment Verified
       </div>
-      <div className="dark:text-emerald-950 text-emerald-50">
+      <div className="dark:text-blue-950 text-blue-50">
         <CheckCircle size={20} />
       </div>
     </div>
@@ -80,7 +80,7 @@ export function AuthorizePayment({
       <Input
         type="text"
         placeholder="Enter magic word..."
-        className="dark:bg-zinc-700 text-base border-none mt-2"
+        className="dark:bg-blue-800 text-base border-none mt-2"
         onChange={(event) => setInput(event.currentTarget.value)}
         onKeyDown={async (event) => {
           if (event.key === "Enter") {

--- a/components/flights/boarding-pass.tsx
+++ b/components/flights/boarding-pass.tsx
@@ -26,59 +26,59 @@ const SAMPLE = {
 
 export function DisplayBoardingPass({ boardingPass = SAMPLE }) {
   return (
-    <div className="bg-yellow-200 p-4 rounded-lg flex flex-col gap-2">
+    <div className="bg-blue-200 p-4 rounded-lg flex flex-col gap-2">
       <div className="flex flex-row justify-between items-center relative">
         <div className="flex flex-col gap-0.5">
-          <div className="text-yellow-800 text-sm sm:text-base">
+          <div className="text-blue-800 text-sm sm:text-base">
             {boardingPass.departure.cityName}
           </div>
-          <div className="text-yellow-800 text-2xl sm:text-3xl font-semibold">
+          <div className="text-blue-800 text-2xl sm:text-3xl font-semibold">
             {boardingPass.departure.airportCode}
           </div>
         </div>
 
         <div className="absolute w-full flex flex-row justify-center">
-          <div className="text-amber-800">
+          <div className="text-blue-700">
             <PlaneTakeoffIcon />
           </div>
         </div>
 
         <div className="flex flex-col gap-0.5">
-          <div className="text-yellow-800 text-sm sm:text-base">
+          <div className="text-blue-800 text-sm sm:text-base">
             {boardingPass.arrival.cityName}
           </div>
-          <div className="text-yellow-800 text-2xl sm:text-3xl font-semibold text-right">
+          <div className="text-blue-800 text-2xl sm:text-3xl font-semibold text-right">
             {boardingPass.arrival.airportCode}
           </div>
         </div>
       </div>
 
-      <div className="h-px grow bg-yellow-600/20" />
+      <div className="h-px grow bg-blue-600/20" />
 
       <div className="flex flex-row justify-between">
         <div className="flex flex-col gap-0.5">
-          <div className="text-yellow-900 text-sm font-medium sm:text-base">
+          <div className="text-blue-900 text-sm font-medium sm:text-base">
             Passenger
           </div>
-          <div className="text-lg text-yellow-700">
+          <div className="text-lg text-blue-700">
             {boardingPass.passengerName}
           </div>
         </div>
 
         <div className="flex flex-col gap-0.5">
-          <div className="text-yellow-900 text-sm font-medium sm:text-base">
+          <div className="text-blue-900 text-sm font-medium sm:text-base">
             Gate
           </div>
-          <div className="text-lg text-yellow-700">
+          <div className="text-lg text-blue-700">
             {boardingPass.departure.gate}
           </div>
         </div>
 
         <div className="flex flex-col gap-0.5">
-          <div className="text-yellow-900 text-sm font-medium sm:text-base">
+          <div className="text-blue-900 text-sm font-medium sm:text-base">
             Boards
           </div>
-          <div className="text-lg text-yellow-700">
+          <div className="text-lg text-blue-700">
             {format(new Date(boardingPass.departure.timestamp), "h:mma")}
           </div>
         </div>

--- a/components/flights/flight-status.tsx
+++ b/components/flights/flight-status.tsx
@@ -54,7 +54,7 @@ export function Row({ row = SAMPLE.arrival, type = "arrival" }) {
       </div>
 
       <div className="flex flex-col gap-1 items-end justify-center mt-auto">
-        <div className="text-sm sm:text-sm bg-amber-400 rounded-md w-fit px-2 text-amber-900">
+        <div className="text-sm sm:text-sm bg-blue-400 rounded-md w-fit px-2 text-blue-900">
           {row.gate}
         </div>
         <div className="text-sm text-muted-foreground">

--- a/components/flights/list-flights.tsx
+++ b/components/flights/list-flights.tsx
@@ -91,7 +91,7 @@ export function ListFlights({
       {results.flights.map((flight) => (
         <div
           key={flight.id}
-          className="cursor-pointer flex flex-row border-b dark:border-zinc-700 py-2 last-of-type:border-none group"
+          className="cursor-pointer flex flex-row border-b dark:border-blue-800 py-2 last-of-type:border-none group"
           onClick={() => {
             append({
               role: "user",
@@ -136,7 +136,7 @@ export function ListFlights({
 
           <div className="flex flex-col w-32 items-end gap-0.5">
             <div className="flex flex-row gap-2">
-              <div className="text-base sm:text-base text-emerald-600 dark:text-emerald-500">
+              <div className="text-base sm:text-base text-blue-600 dark:text-blue-400">
                 ${flight.priceInUSD}
               </div>
             </div>

--- a/components/flights/select-seats.tsx
+++ b/components/flights/select-seats.tsx
@@ -103,8 +103,8 @@ export function SelectSeats({
                   className={cx(
                     "cursor-pointer group relative size-8 sm:size-10 flex-shrink-0 flex rounded-sm flex-row items-center justify-center",
                     {
-                      "bg-blue-500 hover:bg-pink-500": seat.isAvailable,
-                      "bg-gray-500 cursor-not-allowed": !seat.isAvailable,
+                      "bg-blue-500 hover:bg-blue-400": seat.isAvailable,
+                      "bg-blue-200 cursor-not-allowed": !seat.isAvailable,
                     },
                   )}
                 >
@@ -113,8 +113,8 @@ export function SelectSeats({
                     className={cx(
                       "absolute -top-1 h-2 w-full scale-125 rounded-sm",
                       {
-                        "bg-blue-600 group-hover:bg-pink-600": seat.isAvailable,
-                        "bg-zinc-600 cursor-not-allowed": !seat.isAvailable,
+                        "bg-blue-600 group-hover:bg-blue-500": seat.isAvailable,
+                        "bg-blue-300 cursor-not-allowed": !seat.isAvailable,
                       },
                     )}
                   />
@@ -133,7 +133,7 @@ export function SelectSeats({
           </div>
         </div>
         <div className="flex flex-row items-center gap-2">
-          <div className="size-4 bg-gray-500 rounded-sm" />
+          <div className="size-4 bg-blue-200 rounded-sm" />
           <div className="text text-muted-foreground font-medium text-sm">
             Unavailable
           </div>


### PR DESCRIPTION
## Summary

- Replaces the entire color palette with blue tones across the app — both light and dark mode
- Updates CSS custom properties in `globals.css` to a full blue-based palette (backgrounds, surfaces, borders, rings, charts)
- Replaces all hardcoded `zinc-*`, `gray-*`, `amber-*`, `emerald-*`, `yellow-*`, and `indigo-*` Tailwind classes with `blue-*` equivalents in every component

## Files changed

| File | Change |
|---|---|
| `app/globals.css` | Full blue palette for all CSS custom properties (light + dark) |
| `components/custom/navbar.tsx` | Slash icon + title text → blue |
| `components/custom/message.tsx` | Avatar icon + message text → blue |
| `components/custom/multimodal-input.tsx` | Suggested action cards + paperclip button → blue |
| `components/custom/history.tsx` | All sidebar text, hover states, skeletons → blue |
| `components/custom/overview.tsx` | Card text → blue |
| `components/custom/auth-form.tsx` | Label text → blue |
| `components/custom/preview-attachment.tsx` | Spinner + filename → blue |
| `components/custom/weather.tsx` | Night mode colors → blue (day mode was already blue) |
| `components/flights/boarding-pass.tsx` | Yellow theme → blue theme |
| `components/flights/flight-status.tsx` | Amber gate badge → blue |
| `components/flights/select-seats.tsx` | Gray unavailable seats + pink hover → blue |
| `components/flights/list-flights.tsx` | Emerald price + zinc border → blue |
| `components/flights/authorize-payment.tsx` | Emerald payment success + zinc input → blue |
| `app/(auth)/login/page.tsx` | Gray text → blue |
| `app/(auth)/register/page.tsx` | Gray text → blue |